### PR TITLE
Require a PSR-7 implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "equip/framework": "^1.0",
         "josegonzalez/dotenv": "^2.0",
-        "monolog/monolog": "^1.19"
+        "monolog/monolog": "^1.19",
+        "zendframework/zend-diactoros": "^1.0.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The framework does not need a specific implementation, only the project
that uses the Diactoros configuration needs it.

Refs equip/framework#46
