### PR TITLE
Update serve helper command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ development web server:
 
 ```bash
 cd equip-project
-bin/start-server
+bin/serve
 ```
 
 You can then browse to <http://localhost:8000/hello> and see JSON output:

--- a/bin/serve
+++ b/bin/serve
@@ -6,4 +6,4 @@ if [ -n "$1" ]; then
     PORT="$1"
 fi
 
-php -S localhost:$PORT -t web/ web/index.php
+php -S localhost:$PORT -t public/ public/index.php

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,5 @@
         "josegonzalez/dotenv": "^2.0",
         "monolog/monolog": "^1.19",
         "zendframework/zend-diactoros": "^1.0.4"
-    },
-    "scripts": {
-        "serve": "php -S 0.0.0.0:8000 -t public/ public/index.php"
     }
 }


### PR DESCRIPTION
Composer scripts self-terminate and the `serve` command should be long
running. Remove the composer command and update `bin/serve` to use the
new file paths.
